### PR TITLE
Add Mageia information

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ sequential (nonprogressive) JPEGs due to faster decompression speeds they offer.
     *   On Fedora, do `dnf install libpng-devel`. 
     *   On Arch Linux, do `pacman -S libpng`.
     *   On Alpine Linux, do `apk add libpng-dev`.
+    *   On Mageia Cauldron, do `urpmi libpng-devel gcc-g++`, or `dnf install libpng-devel gcc-g++`, or install the binary from the Mageia repositoy using `urpmi guetzli`
 3.  Run `make` and expect the binary to be created in `bin/Release/guetzli`.
 
 ## On Windows


### PR DESCRIPTION
Mageia Cauldron includes guetzli and can be installed with `urpmi guetzli`.
I also think that gcc doesn't come installed by default and has to be included as well.